### PR TITLE
transpile jsx to js on prepublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+index.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,13 @@
+var gulp = require('gulp');
+var reactify = require('gulp-reactify')
+var reactTools = require('react-tools');
+
+// Task: Default
+// ------------------------------------------
+gulp.task('default', ['jsx']);
+
+gulp.task('jsx', function() {
+  gulp.src('*.jsx')
+    .pipe(reactify({reactTools: reactTools}))
+    .pipe(gulp.dest('.'));
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "React mixin for building layered components",
   "main": "index.js",
   "scripts": {
-    "test": ""
+    "test": "",
+    "prepublish": "gulp"
   },
   "repository": {
     "type": "git",
@@ -20,5 +21,10 @@
   "bugs": {
     "url": "https://github.com/akiran/react-layer-mixin/issues"
   },
-  "homepage": "https://github.com/akiran/react-layer-mixin"
+  "homepage": "https://github.com/akiran/react-layer-mixin",
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-reactify": "^2.0.0",
+    "react-tools": "^0.13.1"
+  }
 }


### PR DESCRIPTION
The following should work but fails.  This commit should resolve the problem.

```
npm install react-layer-mixin
```

```
var ReactLayerMixin = require('react-layer-mixin');
```

Because the package references index.js but this doesn't exist on install, currently
