### PR TITLE
Make compatible with React 0.14

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 
 //From https://github.com/Khan/react-components/blob/master/js/layered-component-mixin.jsx
 var LayerMixin = {
@@ -17,9 +18,9 @@ var LayerMixin = {
   _renderLayer: function() {
     var layerElement = this.renderLayer();
     if (layerElement === null) {
-        React.render(React.createElement("noscript", null), this._layer);
+        ReactDOM.render(React.createElement("noscript", null), this._layer);
     } else {
-        React.render(layerElement, this._layer);
+        ReactDOM.render(layerElement, this._layer);
     }
 
     if (this.layerDidMount) {
@@ -31,7 +32,7 @@ var LayerMixin = {
     if (this.layerWillUnmount) {
       this.layerWillUnmount(this._layer);
     }
-    React.unmountComponentAtNode(this._layer);
+    ReactDOM.unmountComponentAtNode(this._layer);
   }
 };
 

--- a/index.jsx
+++ b/index.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 
 //From https://github.com/Khan/react-components/blob/master/js/layered-component-mixin.jsx
 var LayerMixin = {
@@ -17,9 +18,9 @@ var LayerMixin = {
   _renderLayer: function() {
     var layerElement = this.renderLayer();
     if (layerElement === null) {
-        React.render(<noscript />, this._layer);
+        ReactDOM.render(<noscript />, this._layer);
     } else {
-        React.render(layerElement, this._layer);
+        ReactDOM.render(layerElement, this._layer);
     }
 
     if (this.layerDidMount) {
@@ -31,7 +32,7 @@ var LayerMixin = {
     if (this.layerWillUnmount) {
       this.layerWillUnmount(this._layer);
     }
-    React.unmountComponentAtNode(this._layer);
+    ReactDOM.unmountComponentAtNode(this._layer);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-layer-mixin",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "React mixin for building layered components",
   "main": "index.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "react-tools": "^0.13.1"
   },
   "peerDependencies": {
-    "react": "<0.14"
+    "react": ">=0.14",
+    "react-dom": ">=0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-layer-mixin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React mixin for building layered components",
   "main": "index.js",
   "scripts": {
@@ -27,5 +27,8 @@
     "gulp": "^3.8.11",
     "gulp-reactify": "^2.0.0",
     "react-tools": "^0.13.1"
+  },
+  "peerDependencies": {
+    "react": "<0.14"
   }
 }


### PR DESCRIPTION
In React 0.14, which is now the most recent, calls to React.render() throw warning messages to the console.

This PR makes react-layer-mixin version 0.2 compatible only up to React 0.13 and makes react-layer-mixin 0.3.0 require at least React 0.14
